### PR TITLE
chore: Add GitHub Issue Templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+### Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### Actual Behavior
+A clear and concise description of what actually happened.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Environment
+- OS: [e.g. Ubuntu 22.04, macOS 13.0]
+- Go Version: [e.g. 1.21.0]
+- ShieldX Version: [e.g. v0.1.0]
+
+### Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+---
+
+### Is your feature request related to a problem?
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional Context
+Add any other context, screenshots, or examples about the feature request here.
+
+### Benefits
+Explain how this feature would benefit the project and its users.


### PR DESCRIPTION
## Summary
Created structured GitHub Issue Templates to improve contributor experience when reporting bugs or requesting features.

## Changes
- Added `bug_report.md` template with sections for:
  - Bug description
  - Steps to reproduce
  - Expected vs actual behavior
  - Environment details
  - Screenshots
- Added `feature_request.md` template with sections for:
  - Problem description
  - Proposed solution
  - Alternative considerations
  - Benefits analysis

## Why This Matters
Having structured issue templates helps contributors provide complete, useful information upfront, reducing back-and-forth communication and speeding up issue triage.

Closes #20